### PR TITLE
feat: permite assessores marcarem minutado em pedidos do juiz

### DIFF
--- a/index.html
+++ b/index.html
@@ -2976,8 +2976,8 @@
 
             let botoesAcao = '';
             if (pedido.status === 'pendente') {
-                // Se o usuário atual é o assessor responsável ou é juiz, pode marcar como minutado
-                const podeMinutar = currentUser.isJuiz || pedido.assessorId === currentUser.assessorId;
+                // Se o usuário atual é o assessor responsável, é juiz, ou o pedido foi cadastrado pelo juiz (assessorId null), pode marcar como minutado
+                const podeMinutar = currentUser.isJuiz || pedido.assessorId === currentUser.assessorId || !pedido.assessorId;
                 const podeEditarExcluir = pedido.assessorId === currentUser.assessorId || currentUser.isJuiz;
 
                 if (podeEditarExcluir) {


### PR DESCRIPTION
Ajusta a lógica de permissão no Balcão Virtual para que qualquer assessor possa marcar como minutado os pedidos cadastrados pelo juiz (onde assessorId é null).