### PR TITLE
feat: adiciona meta Processos +10 Anos ao sistema de metas

### DIFF
--- a/index.html
+++ b/index.html
@@ -718,6 +718,7 @@
                         <option value="acoes_penais">Meta 4 - Ações Penais</option>
                         <option value="juri">Meta - Tribunal do Júri</option>
                         <option value="violencia_domestica">Meta - Violência Doméstica</option>
+                        <option value="mais_dez_anos">Meta - Processos + 10 Anos</option>
                     </select>
                 </div>
                 <div id="meta-prazo-badge" class="text-sm text-gray-500">
@@ -1690,6 +1691,28 @@
                     'transitado': { nome: 'Trânsito em Julgado', ordem: 11 },
                     'execucao': { nome: 'Execução', ordem: 12 }
                 }
+            },
+            'mais_dez_anos': {
+                id: 'mais_dez_anos',
+                nome: 'Meta - Processos + 10 Anos',
+                prazoFinal: '2026-12-19',
+                descricao: 'Acompanhamento dos processos com mais de 10 anos de tramitação',
+                cor: 'red',
+                colecaoFirebase: 'processosMetaMaisDezAnos',
+                fases: {
+                    'triagem': { nome: 'Triagem', ordem: 1 },
+                    'analise': { nome: 'Análise Processual', ordem: 2 },
+                    'providencias': { nome: 'Providências Cartorárias', ordem: 3 },
+                    'intimacoes': { nome: 'Intimações Pendentes', ordem: 4 },
+                    'audiencia': { nome: 'Audiência', ordem: 5 },
+                    'pericia': { nome: 'Perícia/Diligências', ordem: 6 },
+                    'alegacoes': { nome: 'Alegações Finais', ordem: 7 },
+                    'concluso': { nome: 'Concluso para Sentença', ordem: 8 },
+                    'sentenca': { nome: 'Sentença', ordem: 9 },
+                    'recurso': { nome: 'Recurso', ordem: 10 },
+                    'transitado': { nome: 'Trânsito em Julgado', ordem: 11 },
+                    'arquivado': { nome: 'Arquivado/Baixado', ordem: 12 }
+                }
             }
         };
 
@@ -1716,6 +1739,7 @@
             if (metaAtual === 'acoes_penais') return processosMetaAcoesPenais;
             if (metaAtual === 'juri') return processosMetaJuri;
             if (metaAtual === 'violencia_domestica') return processosMetaViolenciaDomestica;
+            if (metaAtual === 'mais_dez_anos') return processosMetaMaisDezAnos;
             return {};
         }
 
@@ -1741,6 +1765,7 @@
         let processosMetaAcoesPenais = {};
         let processosMetaJuri = {};
         let processosMetaViolenciaDomestica = {};
+        let processosMetaMaisDezAnos = {};
 
         // ==================== UTILITÁRIOS ====================
         
@@ -4240,6 +4265,8 @@
                     processosMetaJuri[id] = novoProcesso;
                 } else if (metaAtual === 'violencia_domestica') {
                     processosMetaViolenciaDomestica[id] = novoProcesso;
+                } else if (metaAtual === 'mais_dez_anos') {
+                    processosMetaMaisDezAnos[id] = novoProcesso;
                 }
                 limparFormularioMeta();
                 showNotification('Processo cadastrado localmente', 'warning');
@@ -4341,6 +4368,8 @@
                     processosMetaJuri[id] = processoAtualizado;
                 } else if (metaAtual === 'violencia_domestica') {
                     processosMetaViolenciaDomestica[id] = processoAtualizado;
+                } else if (metaAtual === 'mais_dez_anos') {
+                    processosMetaMaisDezAnos[id] = processoAtualizado;
                 }
                 fecharModalEdicaoProcessoMeta();
                 showNotification('Processo atualizado localmente', 'warning');
@@ -4377,6 +4406,8 @@
                     delete processosMetaJuri[id];
                 } else if (metaAtual === 'violencia_domestica') {
                     delete processosMetaViolenciaDomestica[id];
+                } else if (metaAtual === 'mais_dez_anos') {
+                    delete processosMetaMaisDezAnos[id];
                 }
                 showNotification('Processo removido localmente', 'warning');
                 renderMetasAcoesPenais();
@@ -4936,6 +4967,8 @@
                             processosMetaJuri[id] = novoProcesso;
                         } else if (metaAtual === 'violencia_domestica') {
                             processosMetaViolenciaDomestica[id] = novoProcesso;
+                        } else if (metaAtual === 'mais_dez_anos') {
+                            processosMetaMaisDezAnos[id] = novoProcesso;
                         }
                     }
                     importados++;
@@ -5274,6 +5307,17 @@
                     log(`Processos Meta Violência Doméstica carregados: ${Object.keys(processosMetaViolenciaDomestica).length}`);
 
                     if (currentView === 'metas' && metaAtual === 'violencia_domestica') {
+                        renderMetasDashboard();
+                        renderListaMetas();
+                    }
+                });
+
+                // Listener para processos da Meta + 10 Anos
+                database.ref('processosMetaMaisDezAnos').on('value', (snapshot) => {
+                    processosMetaMaisDezAnos = snapshot.val() || {};
+                    log(`Processos Meta +10 Anos carregados: ${Object.keys(processosMetaMaisDezAnos).length}`);
+
+                    if (currentView === 'metas' && metaAtual === 'mais_dez_anos') {
                         renderMetasDashboard();
                         renderListaMetas();
                     }


### PR DESCRIPTION
Cria novo painel de acompanhamento para processos com mais de 10 anos, seguindo o mesmo padrão das outras metas (Ações Penais, Júri, Violência Doméstica).

Inclui:
- Configuração no METAS_CONFIG com fases específicas
- Variável processosMetaMaisDezAnos para armazenar processos
- Listener do Firebase para sincronização em tempo real
- Operações de salvar/atualizar/excluir/importar
- Opção no seletor de metas no HTML